### PR TITLE
Tesseract timeout

### DIFF
--- a/js/admin.elements.js
+++ b/js/admin.elements.js
@@ -31,7 +31,8 @@
 
 var fts_tesseract_elements = {
 	tesseract_div: null,
-	tesseract_ocr: null,
+	tesseract_ocr: null,	
+	tesseract_timeout: null,
 	tesseract_psm: null,
 	tesseract_lang: null,
 	tesseract_pdf: null,

--- a/js/admin.elements.js
+++ b/js/admin.elements.js
@@ -39,6 +39,7 @@ var fts_tesseract_elements = {
 
 	init: function () {
 		fts_tesseract_elements.tesseract_div = $('#files_ocr-tesseract');
+		fts_tesseract_elements.tesseract_timeout = $('#tesseract_timeout');
 		fts_tesseract_elements.tesseract_psm = $('#tesseract_psm');
 		fts_tesseract_elements.tesseract_lang = $('#tesseract_lang');
 		fts_tesseract_elements.tesseract_ocr = $('#tesseract_ocr');
@@ -46,6 +47,7 @@ var fts_tesseract_elements = {
 		fts_tesseract_elements.tesseract_pdf_limit = $('#tesseract_pdf_limit');
 
 		fts_tesseract_elements.tesseract_ocr.on('change', fts_tesseract_elements.updateSettings);
+		fts_tesseract_elements.tesseract_timeout.on('change', fts_tesseract_elements.updateSettings);
 		fts_tesseract_elements.tesseract_psm.on('change', fts_tesseract_elements.updateSettings);
 		fts_tesseract_elements.tesseract_lang.on('change', fts_tesseract_elements.updateSettings);
 		fts_tesseract_elements.tesseract_pdf.on('change', fts_tesseract_elements.updateSettings);

--- a/js/admin.settings.js
+++ b/js/admin.settings.js
@@ -47,6 +47,7 @@ var fts_tesseract_settings = {
 
 	updateSettingPage: function (result) {
 		fts_tesseract_elements.tesseract_ocr.prop('checked', (result.tesseract_enabled === '1'));
+		fts_tesseract_elements.tesseract_timeout.val(result.tesseract_timeout);
 		fts_tesseract_elements.tesseract_psm.val(result.tesseract_psm);
 		fts_tesseract_elements.tesseract_lang.val(result.tesseract_lang);
 		fts_tesseract_elements.tesseract_pdf.prop('checked', (result.tesseract_pdf === '1'));
@@ -70,6 +71,7 @@ var fts_tesseract_settings = {
 
 		var data = {
 			tesseract_enabled: (fts_tesseract_elements.tesseract_ocr.is(':checked')) ? 1 : 0,
+			tesseract_timeout: fts_tesseract_elements.tesseract_timeout.val(),
 			tesseract_psm: fts_tesseract_elements.tesseract_psm.val(),
 			tesseract_lang: fts_tesseract_elements.tesseract_lang.val(),
 			tesseract_pdf: (fts_tesseract_elements.tesseract_pdf.is(':checked')) ? 1 : 0,

--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -45,6 +45,7 @@ class ConfigService {
 
 
 	const TESSERACT_ENABLED = 'tesseract_enabled';
+	const TESSERACT_TIMEOUT = 'tesseract_timeout';
 	const TESSERACT_PSM = 'tesseract_psm';
 	const TESSERACT_LANG = 'tesseract_lang';
 	const TESSERACT_PDF = 'tesseract_pdf';
@@ -52,6 +53,7 @@ class ConfigService {
 
 	public $defaults = [
 		self::TESSERACT_ENABLED   => '0',
+		self::TESSERACT_TIMEOUT   => '300',
 		self::TESSERACT_PSM       => '4',
 		self::TESSERACT_LANG      => 'eng',
 		self::TESSERACT_PDF       => '0',
@@ -80,6 +82,7 @@ class ConfigService {
 			[
 				'version'   => $this->getAppValue('installed_version'),
 				'enabled'   => $this->getAppValue(self::TESSERACT_ENABLED),
+				'timeout'   => $this->getAppValue(self::TESSERACT_TIMEOUT),
 				'psm'       => $this->getAppValue(self::TESSERACT_PSM),
 				'lang'      => $this->getAppValue(self::TESSERACT_LANG),
 				'pdf'       => $this->getAppValue(self::TESSERACT_PDF),

--- a/lib/Service/TesseractService.php
+++ b/lib/Service/TesseractService.php
@@ -187,7 +187,7 @@ class TesseractService {
 		$this->logger->debug('generating the TesseractOCR wrapper', ['path' => $path]);
 
 		$ocr = new TesseractOCR($path);
-		$timeout = explode(',', $this->configService->getAppValue(ConfigService::TESSERACT_TIMEOUT));
+		$timeout = $this->configService->getAppValue(ConfigService::TESSERACT_TIMEOUT);
 		$ocr->psm($this->configService->getAppValue(ConfigService::TESSERACT_PSM));
 		$lang = explode(',', $this->configService->getAppValue(ConfigService::TESSERACT_LANG));
 		call_user_func_array([$ocr, 'lang'], array_map('trim', $lang));

--- a/lib/Service/TesseractService.php
+++ b/lib/Service/TesseractService.php
@@ -187,6 +187,7 @@ class TesseractService {
 		$this->logger->debug('generating the TesseractOCR wrapper', ['path' => $path]);
 
 		$ocr = new TesseractOCR($path);
+		$timeout = explode(',', $this->configService->getAppValue(ConfigService::TESSERACT_TIMEOUT));
 		$ocr->psm($this->configService->getAppValue(ConfigService::TESSERACT_PSM));
 		$lang = explode(',', $this->configService->getAppValue(ConfigService::TESSERACT_LANG));
 		call_user_func_array([$ocr, 'lang'], array_map('trim', $lang));
@@ -197,7 +198,7 @@ class TesseractService {
 //		}
 
 		try {
-			$result = $ocr->run();
+			$result = $ocr->run($timeout);
 			$this->logger->debug('OCR command ran smoothly');
 		} catch (Exception $e) {
 			$this->logger->notice('failed to OCR', [

--- a/templates/settings.admin.php
+++ b/templates/settings.admin.php
@@ -81,7 +81,7 @@ Util::addScript(Application::APP_NAME, 'admin');
 			<div class="div-table-col div-table-col-left">
 				<span class="leftcol">Tesseract timeout</span>
 				<br/>
-				<em>set timeout for tesseract process , some took to long</em>
+				<em>Sets a timeout in seconds for the Tesseract process. So that tesseract terminates before the database connection times out.</em>
 			</div>
 			<div class="div-table-col">
 				<input type="text" class="small" id="tesseract_timeout" value=""/>

--- a/templates/settings.admin.php
+++ b/templates/settings.admin.php
@@ -67,24 +67,23 @@ Util::addScript(Application::APP_NAME, 'admin');
 
 		<div class="div-table-row tesseract_ocr_enabled">
 			<div class="div-table-col div-table-col-left">
-				<span class="leftcol">Languages</span>
-				<br/>
-				<em>list of installed language, separated by <b>,</b> (comma)</em>
-			</div>
-			<div class="div-table-col">
-				<input type="text" class="big" id="tesseract_lang" value=""/>
-			</div>
-		</div>
-
-		
-		<div class="div-table-row tesseract_ocr_enabled">
-			<div class="div-table-col div-table-col-left">
 				<span class="leftcol">Tesseract timeout</span>
 				<br/>
 				<em>Sets a timeout in seconds for the Tesseract process. So that tesseract terminates before the database connection times out.</em>
 			</div>
 			<div class="div-table-col">
 				<input type="text" class="small" id="tesseract_timeout" value=""/>
+			</div>
+		</div>
+		
+		<div class="div-table-row tesseract_ocr_enabled">
+			<div class="div-table-col div-table-col-left">
+				<span class="leftcol">Languages</span>
+				<br/>
+				<em>list of installed language, separated by <b>,</b> (comma)</em>
+			</div>
+			<div class="div-table-col">
+				<input type="text" class="big" id="tesseract_lang" value=""/>
 			</div>
 		</div>
 		

--- a/templates/settings.admin.php
+++ b/templates/settings.admin.php
@@ -76,6 +76,18 @@ Util::addScript(Application::APP_NAME, 'admin');
 			</div>
 		</div>
 
+		
+		<div class="div-table-row tesseract_ocr_enabled">
+			<div class="div-table-col div-table-col-left">
+				<span class="leftcol">Tesseract timeout</span>
+				<br/>
+				<em>set timeout for tesseract process , some took to long</em>
+			</div>
+			<div class="div-table-col">
+				<input type="text" class="small" id="tesseract_timeout" value=""/>
+			</div>
+		</div>
+		
 		<div class="div-table-row tesseract_ocr_enabled">
 			<div class="div-table-col div-table-col-left">
 				<span class="leftcol">PDF</span>


### PR DESCRIPTION
For some documents and small machines, Tesseract takes too much time and the indexer stops working afterwards for no apparent reason. This patch should solve this issue with a timeout configurable on the admin page.